### PR TITLE
POB-2025: offline payment code structure

### DIFF
--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Parameter.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Parameter.java
@@ -2,13 +2,14 @@ package jp.pokepay.pokepaylib;
 
 import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 public class Parameter {
 
     public Map<String, Object> toMap() {
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String, Object> rt = mapper.convertValue(this, Map.class);
-        return rt;
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        return mapper.convertValue(this, Map.class);
     }
 
 }

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Parameters/Product.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Parameters/Product.java
@@ -2,21 +2,24 @@ package jp.pokepay.pokepaylib.Parameters;
 
 import android.support.annotation.NonNull;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import jp.pokepay.pokepaylib.Parameter;
 
+@JsonSerialize
 public class Product extends Parameter {
 
     @NonNull
-    String jan_code;
+    public String jan_code;
     @NonNull
-    String name;
-    double unit_price;
-    double price;
-    boolean is_discounted;
-    String other;
+    public String name;
+    public double unit_price;
+    public double price;
+    public boolean is_discounted;
+    public String other;
 
     public static Product create(
             String jan_code_primary, String jan_code_secondary, String name,

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Pokepay.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Pokepay.java
@@ -63,7 +63,7 @@ public class Pokepay {
             return new GetTerminal().send(accessToken);
         }
 
-        private String parseAsPokeregiToken(String token) {
+        public String parseAsPokeregiToken(String token) {
             // * {25 ALNUM} - (Pokeregi_V1 OfflineMode QR)
             final Pattern V1_QR_REG = Pattern.compile("^([0-9A-Z]{25})$");
             // * https://www.pokepay.jp/pd?={25 ALNUM} - (Pokeregi_V1 OfflineMode NFC)
@@ -72,11 +72,11 @@ public class Pokepay {
             // matching
             final Matcher v1 = V1_QR_REG.matcher(token);
             if (v1.find()) {
-                return v1.group(0);
+                return v1.group(1);
             }
             final Matcher v2 = V1_NFC_V2_QR_NFC_REG.matcher(token);
             if (v2.find()) {
-                return v2.group(0);
+                return v2.group(1);
             }
             return "";
         }

--- a/sample/src/main/java/jp/pokepay/pokepay/LowLevelAPITests.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/LowLevelAPITests.java
@@ -58,16 +58,17 @@ import jp.pokepay.pokepaylib.Responses.Terminal;
 import jp.pokepay.pokepaylib.Responses.UserTransaction;
 
 public class LowLevelAPITests {
-    private String merchantAccessToken = "7mL_asUSVHUZhW11nDJzlm-Xa7-01VjgVBPi8Hd43UAqYpMCEfEuzLPGWfKr0VU9";// 購入店を想定
-    private String customerAccessToken = "fWhzN-3FpIHdNcak5304hJHS7RTSTIpEWfdt0DUwZGAjU947OAV-fWBmPoKjSG6w";// 購入客を想定(残高あり)
+    private final String merchantAccessToken = "eYNDMo_cAqPgxMW3qlMv9968awTwFpiwi_rR8XrRhaO6zMOgMfem2q1wfnlluo-v";// 購入店を想定
+    private final String merchantAccountId = "55694dbd-582a-442f-80e1-a23e0f49b3cd";
+    private final String customerAccessToken = "S-WAIYRN6rVdb77rYGgMeRQgMLuQ2ZAM0Fo8HfocrrTWxH7tsehCkD6JJSjGhs-0";// 購入客を想定(残高あり)
+    private final String pokepayMoneyId = "87c012b9-e8ea-4e2f-97ed-764e5ac0167f";
 
     public LowLevelAPITests() {
         Pokepay.setEnv(Env.DEVELOPMENT);
     }
 
     public Product[] getProducts() {
-        Product[] products = null;
-        products = new Product[3];
+        Product[] products = new Product[3];
         products[0] = Product.create("4569951116179", null, "ハムスこくとろカレー140g", 150, 300, false, 2.0, "個");
         products[1] = Product.create("4569951116179", null, "SCカレーの王様80g", 160, 160, false, 1.0, "個");
         products[2] = Product.create("4569951116179", "4569951116179", "牛肩ロースしゃぶしゃぶ用", 200, 600, false, 3.0, "100グラム");
@@ -98,7 +99,7 @@ public class LowLevelAPITests {
 
     public String AccountTest() throws BankRequestError, ProcessingError {
         // privateMoneyIdでアカウントの作成 //
-        CreateAccount createAccount = new CreateAccount("accountTest", "216d1e39-3acb-454e-9fbf-74c33c5bfd5d");
+        CreateAccount createAccount = new CreateAccount("accountTest", pokepayMoneyId);
         Account account = createAccount.send(merchantAccessToken);
         // アカウントの確認 //
         GetAccount getAccount = new GetAccount(account.id);
@@ -290,7 +291,7 @@ public class LowLevelAPITests {
         Terminal terminal = getTerminal.send(customerAccessToken);
         System.out.println("terminal info got " + terminal.toString());
         // Billの作成 //
-        CreateBill createBill = new CreateBill(1.0, "transaction test", null, null);
+        CreateBill createBill = new CreateBill(1.0, null, null, null);
         Bill bill = createBill.send(merchantAccessToken);
         System.out.println("bill created " + bill.toString());
         // 上記のBillで取引を作成 //
@@ -356,7 +357,7 @@ public class LowLevelAPITests {
         }
 
         System.out.println("客のアクセストークンでCpmをcreate");
-        CreateAccount createAccount = new CreateAccount("accountTest", "216d1e39-3acb-454e-9fbf-74c33c5bfd5d");
+        CreateAccount createAccount = new CreateAccount("accountTest", pokepayMoneyId);
         Account account = createAccount.send(customerAccessToken);
         CreateAccountCpmToken createAccountCpmToken = new CreateAccountCpmToken(account.id, CreateAccountCpmToken.SCOPE_BOTH, 100, "data");
         AccountCpmToken cpmToken = createAccountCpmToken.send(customerAccessToken);

--- a/sample/src/main/java/jp/pokepay/pokepay/MessagingAPITests.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/MessagingAPITests.java
@@ -15,8 +15,8 @@ import jp.pokepay.pokepaylib.Responses.PaginatedMessages;
 import jp.pokepay.pokepaylib.Responses.Terminal;
 
 public class MessagingAPITests {
-    private String accessToken1 = "7mL_asUSVHUZhW11nDJzlm-Xa7-01VjgVBPi8Hd43UAqYpMCEfEuzLPGWfKr0VU9";// ユーザ１　購入店を想定
-    private String accessToken2 = "oNTvWHFqv512JJQhUVgAwCx7LphHVpHFAp_jDMQ62THIN9iOwNfUXA9nMkI66xoA";// ユーザ２　購入客を想定(残高あり)
+    private String accessToken1 = "eYNDMo_cAqPgxMW3qlMv9968awTwFpiwi_rR8XrRhaO6zMOgMfem2q1wfnlluo-v";// ユーザ１　購入店を想定
+    private String accessToken2 = "S-WAIYRN6rVdb77rYGgMeRQgMLuQ2ZAM0Fo8HfocrrTWxH7tsehCkD6JJSjGhs-0";// ユーザ２　購入客を想定(残高あり)
 
     public MessagingAPITests(){
         Pokepay.setEnv(Env.DEVELOPMENT);

--- a/sample/src/main/java/jp/pokepay/pokepay/QRCameraActivity.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/QRCameraActivity.java
@@ -26,7 +26,7 @@ public class QRCameraActivity extends AppCompatActivity {
     private String url;
     private ProgressDialog progressDialog;
 
-    private String customerAccessToken = "oNTvWHFqv512JJQhUVgAwCx7LphHVpHFAp_jDMQ62THIN9iOwNfUXA9nMkI66xoA";
+    private String customerAccessToken = "S-WAIYRN6rVdb77rYGgMeRQgMLuQ2ZAM0Fo8HfocrrTWxH7tsehCkD6JJSjGhs-0";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/sample/src/main/java/jp/pokepay/pokepay/ScannerActivity.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/ScannerActivity.java
@@ -18,7 +18,7 @@ import jp.pokepay.pokepaylib.Responses.Terminal;
 
 public class ScannerActivity extends AppCompatActivity {
     private BLEController bleController;
-    private String accessToken = "oNTvWHFqv512JJQhUVgAwCx7LphHVpHFAp_jDMQ62THIN9iOwNfUXA9nMkI66xoA";
+    private String accessToken = "S-WAIYRN6rVdb77rYGgMeRQgMLuQ2ZAM0Fo8HfocrrTWxH7tsehCkD6JJSjGhs-0";
     private ProgressDialog progressDialog;
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)

--- a/sample/src/main/java/jp/pokepay/pokepay/View02Activity.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/View02Activity.java
@@ -28,8 +28,8 @@ import jp.pokepay.pokepaylib.TokenInfo;
 public class View02Activity extends AppCompatActivity {
     private String clientId = "LlMbGiWr7ouItgi5-7mRSQ";
     private String clientSecret = "2CZtBW6hzTCYRZhLLsPxdoeG7ktpDGrJ4GsfxTjLOjXFHQeizsSBUNR0";
-    private String accessToken1 = "7mL_asUSVHUZhW11nDJzlm-Xa7-01VjgVBPi8Hd43UAqYpMCEfEuzLPGWfKr0VU9";
-    private String accessToken2 = "oNTvWHFqv512JJQhUVgAwCx7LphHVpHFAp_jDMQ62THIN9iOwNfUXA9nMkI66xoA"; // 購入客を想定(残高あり)
+    private String accessToken1 = "eYNDMo_cAqPgxMW3qlMv9968awTwFpiwi_rR8XrRhaO6zMOgMfem2q1wfnlluo-v";
+    private String accessToken2 = "S-WAIYRN6rVdb77rYGgMeRQgMLuQ2ZAM0Fo8HfocrrTWxH7tsehCkD6JJSjGhs-0"; // 購入客を想定(残高あり)
     EditText editTextOauth;
     private ProgressDialog progressDialog;
 

--- a/sample/src/main/java/jp/pokepay/pokepay/View03Activity.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/View03Activity.java
@@ -259,6 +259,27 @@ public class View03Activity extends AppCompatActivity {
                 }).start();
             }
         });
+
+        Button button10 = (Button)findViewById(R.id.buttonParseAsPokeregiToken);
+        button10.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        handler.sendEmptyMessage(1);
+                        final Message msg = Message.obtain();
+                        try {
+                            final String result = lowLevelAPITests.ParseAsPokeregiTokenTest();
+                            msg.obj = "ParseAsPokeregiToken: \n" + result;
+                        } catch (ProcessingError e) {
+                            msg.obj = "ProcessingError: " + e.getMessage();
+                        }
+                        handler.sendMessage(msg);
+                    }
+                }).start();
+            }
+        });
     }
 
     private Handler handler = new Handler(new Handler.Callback() {

--- a/sample/src/main/res/layout/activity_view03.xml
+++ b/sample/src/main/res/layout/activity_view03.xml
@@ -105,4 +105,12 @@
         android:layout_below="@+id/buttonMessage"
         android:text="CpmAPI Test" />
 
+    <Button
+        android:id="@+id/buttonParseAsPokeregiToken"
+        android:layout_width="180dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentStart="true"
+        android:layout_below="@+id/buttonCpm"
+        android:text="pokeregiToken Test" />
+
 </RelativeLayout>


### PR DESCRIPTION
Support Pokeregi v2 token.
Before this PR, User had to parse and extract token that is read from Pokeregi v1 NFC and set it to scanToken().
WIth this PR, User doesn't have to care about token format or Pokeregi version and can simply set raw token to scanToken(). 