### PR TITLE
Fix some response and fix for JPQR cpm-token

### DIFF
--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Pokepay.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Pokepay.java
@@ -101,7 +101,7 @@ public class Pokepay {
                     TokenInfo.Type.CHECK,
                     new GetCheck(uuid).send(accessToken)
                 );
-            } else if (token.matches("^[0-9]{12}$")) {
+            } else if (token.matches("^[0-9]{20}$")) {
                 return new TokenInfo(
                     TokenInfo.Type.CPM,
                     new GetCpmToken(token).send(accessToken)
@@ -139,7 +139,7 @@ public class Pokepay {
                 final CreateTransactionWithCheck createTransactionWithCheck = new CreateTransactionWithCheck(uuid, accountId);
                 return createTransactionWithCheck.send(accessToken);
             }
-            else if (token.matches("^[0-9]{12}$")) {
+            else if (token.matches("^[0-9]{20}$")) {
                 final CreateTransactionWithCpm createTransactionWithCpm = new CreateTransactionWithCpm(token, accountId, amount, products);
                 return createTransactionWithCpm.send(accessToken);
             }

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/Cashtray.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/Cashtray.java
@@ -22,4 +22,6 @@ public class Cashtray extends Response {
     public Date canceled_at;
     @NonNull
     public String token;
+    public CashtrayAttempt attempt;
+    public UserTransaction transaction;
 }

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/Check.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/Check.java
@@ -27,6 +27,8 @@ public class Check extends Response {
     public boolean is_disabled;
     @NonNull
     public Date expires_at;
+    public Date point_expires_at;
+    public Date point_expires_in_days;
     @NonNull
     public String token;
 }

--- a/sample/src/main/java/jp/pokepay/pokepay/LowLevelAPITests.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/LowLevelAPITests.java
@@ -342,7 +342,7 @@ public class LowLevelAPITests {
 
         System.out.println("Cpmをデタラメにgetして404");
         try {
-            GetCpmToken getCpmToken = new GetCpmToken("000011112222");
+            GetCpmToken getCpmToken = new GetCpmToken("90000022000011112222");
             getCpmToken.send(customerAccessToken);
             throw new ProcessingError("this call should be fail");
         } catch (BankRequestError e) {

--- a/sample/src/main/java/jp/pokepay/pokepay/View02Activity.java
+++ b/sample/src/main/java/jp/pokepay/pokepay/View02Activity.java
@@ -108,7 +108,7 @@ public class View02Activity extends AppCompatActivity {
                         final Message msg = Message.obtain();
                         try {
                             Pokepay.Client client = new Pokepay.Client(accessToken1, View02Activity.this);
-                            final String token = client.createToken(1.0, "AndroidTest bill");
+                            final String token = client.createToken(-1.0, "AndroidTest bill");
                             client = new Pokepay.Client(accessToken2, View02Activity.this,true);
                             final UserTransaction userTransaction = client.scanToken(token);
                             msg.obj = "Success transaction: " + userTransaction.toString();
@@ -133,9 +133,10 @@ public class View02Activity extends AppCompatActivity {
                         handler.sendEmptyMessage(1);
                         final Message msg = Message.obtain();
                         try {
-                            Pokepay.Client client = new Pokepay.Client(accessToken2, View02Activity.this, true);
+                            Pokepay.Client client = new Pokepay.Client(accessToken1, View02Activity.this, true);
                             final String token = client.createToken(1.0, "AndroidTest cashtray");
-                            client = new Pokepay.Client(accessToken1, View02Activity.this);
+                            final TokenInfo info = client.getTokenInfo(token);
+                            client = new Pokepay.Client(accessToken2, View02Activity.this);
                             final UserTransaction userTransaction = client.scanToken(token);
                             msg.obj = "Success transaction: " + userTransaction.toString();
                         } catch (ProcessingError e) {


### PR DESCRIPTION
- サーバのレスポンス変更に対する追従
  - cashtrayにattemptとtransactionを追加
  - checkにpoint_expires_atとpoint_expires_in_daysを追加
- CPMトークンのJPQR対応に追従
  - パターンマッチ式を変更
  - テストケースでの存在しないcpmトークンの形式を変更
- cashtrayのテストで店舗ユーザとエンドユーザのアクセストークンが逆になっていたのを修正