### PR TITLE
OAuth User Setting URL

### DIFF
--- a/pokepaylib/build.gradle
+++ b/pokepaylib/build.gradle
@@ -17,7 +17,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 26
         versionCode 0
-        versionName "1.8.1"
+        versionName "1.8.2"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -60,7 +60,7 @@ uploadArchives {
     repositories {
         mavenDeployer {
             repository url: "file://${repo.absolutePath}"
-            pom.version = '1.8.0'	      // version
+            pom.version = '1.8.2'	      // version
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
             repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/BankAPI/User/GetUserSettingUrl.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/BankAPI/User/GetUserSettingUrl.java
@@ -1,0 +1,19 @@
+package jp.pokepay.pokepaylib.BankAPI.User;
+
+import jp.pokepay.pokepaylib.BankAPI.BankRequest;
+import jp.pokepay.pokepaylib.BankAPI.BankRequestError;
+import jp.pokepay.pokepaylib.ProcessingError;
+import jp.pokepay.pokepaylib.Request;
+import jp.pokepay.pokepaylib.Responses.UserSettingUrl;
+
+public class GetUserSettingUrl extends BankRequest {
+
+    protected final String path() { return "/oauth/full-access"; }
+
+    protected final Request.Method method() { return Request.Method.POST; }
+
+    public final UserSettingUrl send(String accessToken) throws ProcessingError, BankRequestError {
+        return super.send(UserSettingUrl.class, accessToken);
+    }
+
+}

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Pokepay.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Pokepay.java
@@ -26,6 +26,7 @@ import jp.pokepay.pokepaylib.BankAPI.Transaction.CreateTransactionWithCashtray;
 import jp.pokepay.pokepaylib.BankAPI.Transaction.CreateTransactionWithCheck;
 import jp.pokepay.pokepaylib.BankAPI.Transaction.CreateTransactionWithCpm;
 import jp.pokepay.pokepaylib.BankAPI.Transaction.CreateTransactionWithJwt;
+import jp.pokepay.pokepaylib.BankAPI.User.GetUserSettingUrl;
 import jp.pokepay.pokepaylib.OAuthAPI.OAuthRequestError;
 import jp.pokepay.pokepaylib.OAuthAPI.Token.ExchangeAuthCode;
 import jp.pokepay.pokepaylib.Parameters.Product;
@@ -37,6 +38,7 @@ import jp.pokepay.pokepaylib.Responses.Cashtray;
 import jp.pokepay.pokepaylib.Responses.Check;
 import jp.pokepay.pokepaylib.Responses.JwtResult;
 import jp.pokepay.pokepaylib.Responses.Terminal;
+import jp.pokepay.pokepaylib.Responses.UserSettingUrl;
 import jp.pokepay.pokepaylib.Responses.UserTransaction;
 
 public class Pokepay {
@@ -248,6 +250,10 @@ public class Pokepay {
                 Bill bill = createBill.send(accessToken);
                 return getWwwBaseUrl() + "/bills/" + bill.id;
             }
+        }
+
+        public UserSettingUrl getUserSettingUrl() throws ProcessingError, BankRequestError {
+            return new GetUserSettingUrl().send(accessToken);
         }
     }
 

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/UserSettingUrl.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/UserSettingUrl.java
@@ -1,0 +1,10 @@
+package jp.pokepay.pokepaylib.Responses;
+
+import android.support.annotation.NonNull;
+
+import jp.pokepay.pokepaylib.Response;
+
+public class UserSettingUrl extends Response {
+    @NonNull
+    public String url;
+}


### PR DESCRIPTION
### Related Issue
[#3078](https://github.com/pokepay/pokepay-server/issues/3078)

#### Implementation
Added GetUserSettingUrl 

#### QA Method
```Java
Pokepay.setEnv(Env.DEVELOPMENT);
        final Pokepay.Client client = new Pokepay.Client(
            "8DZNjCfqOTwKALYjWa2lYj7we8GYGTGi2UzT4cVERISl6qBIuNurDk4TMdqIUEU", 
            getApplicationContext()
        );
        new Thread(new Runnable() {
            @Override
            public void run() {
                try {
                    UserSettingUrl url = client.getUserSettingUrl();
                    // use url
                } catch (Exception e) {
                    e.printStackTrace();
                }
            }
        }).start();
```