### PR TITLE
Fixed wrong timezone for expires at parameter in creating check

### DIFF
--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/BankAPI/Check/CreateCheck.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/BankAPI/Check/CreateCheck.java
@@ -37,7 +37,7 @@ public class CreateCheck extends BankRequest {
             put("amount", amount);
             put("description", description);
             put("account_id", accountId);
-            put("expires_at", expiresAt != null ? Request.formatter.format(expiresAt) : null);
+            put("expires_at", expiresAt != null ? Request.getFormatter().format(expiresAt) : null);
         }};
     }
 

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Request.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Request.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 import jp.pokepay.pokepaylib.BankAPI.BankRequestError;
 import jp.pokepay.pokepaylib.OAuthAPI.OAuthRequestError;
@@ -24,7 +25,17 @@ import jp.pokepay.pokepaylib.Responses.OAuthError;
 
 public class Request {
 
+    /**
+     * @deprecated use {@link #getFormatter()} instead.
+     */
+    @Deprecated
     public static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'");
+
+    public static final SimpleDateFormat getFormatter() {
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS'Z'");
+        formatter.setTimeZone(TimeZone.getTimeZone("GMT"));
+        return formatter;
+    }
 
     public static enum Method {
         GET("GET"),


### PR DESCRIPTION
### Overview
When creating check, if expiresAt parameter is provided, the created check will have a wrong time.  This is because the time zone for the date formatter is set to local timezone.
This fix will use GMT+00:00 as the default timezone which will the same as the iOS SDK.