### PR TITLE
Update Android build release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /captures
 .externalNativeBuild
 repository/
+gradle.properties

--- a/build.gradle
+++ b/build.gradle
@@ -24,3 +24,110 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+task release {
+    group = 'release'
+    description = 'Performs a complete release: clean, build, tag, publish, and deploy to Sonatype'
+    
+    doLast {
+        // Extract version from pokepaylib/build.gradle
+        println "=========================================="
+        println "Pokepay Android SDK Release Script"
+        println "=========================================="
+        println ""
+        
+        def buildGradleFile = file('pokepaylib/build.gradle')
+        def versionName = null
+        buildGradleFile.eachLine { line ->
+            def matcher = line =~ /versionName\s+"([^"]+)"/
+            if (matcher) {
+                versionName = matcher[0][1]
+            }
+        }
+        
+        if (!versionName) {
+            throw new GradleException("Could not extract version from pokepaylib/build.gradle")
+        }
+        
+        println "Found version: ${versionName}"
+        println ""
+        
+        // Check credentials
+        if (!project.hasProperty('ossrhUsername') || !project.hasProperty('ossrhPassword')) {
+            throw new GradleException("Missing credentials. Please ensure ossrhUsername and ossrhPassword are set in gradle.properties")
+        }
+        
+        println "Credentials loaded successfully"
+        println ""
+        println "Starting release process for version ${versionName}..."
+        println ""
+        
+        // Step 1: Clean and Build
+        println "Step 1/5: Cleaning and building project..."
+        project.tasks.clean.execute()
+        project.tasks.build.execute()
+        println "Build completed successfully"
+        println ""
+        
+        // Step 2: Git Tag
+        println "Step 2/5: Creating and pushing git tag ${versionName}..."
+        def tagResult = "git tag ${versionName}".execute()
+        tagResult.waitFor()
+        if (tagResult.exitValue() != 0) {
+            throw new GradleException("git tag failed (tag may already exist)")
+        }
+        
+        def pushResult = "git push --tags".execute()
+        pushResult.waitFor()
+        if (pushResult.exitValue() != 0) {
+            throw new GradleException("git push --tags failed")
+        }
+        println "Git tag created and pushed successfully"
+        println ""
+        
+        // Step 3: Publish
+        println "Step 3/5: Publishing to Maven repository..."
+        project.tasks.publish.execute()
+        println "Published successfully"
+        println ""
+        
+        // Step 4: Search for open repositories
+        println "Step 4/5: Searching for open repositories..."
+        def searchCmd = [
+            'curl', '-s', '-u', "${project.ossrhUsername}:${project.ossrhPassword}",
+            '-H', 'Accept: application/json',
+            'https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?state=open'
+        ]
+        def searchProc = searchCmd.execute()
+        searchProc.waitFor()
+        if (searchProc.exitValue() != 0) {
+            throw new GradleException("Failed to search for open repositories")
+        }
+        println "Open repositories response:"
+        println searchProc.text
+        println ""
+        
+        // Step 5: Upload to repository
+        println "Step 5/5: Uploading to Sonatype repository..."
+        def uploadCmd = [
+            'curl', '-s', '-u', "${project.ossrhUsername}:${project.ossrhPassword}",
+            '-X', 'POST',
+            "https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/${project.ossrhUsername}/219.104.131.128/jp.pocket-change.pokepay.android-sdk--default-repository",
+            '-H', 'Content-Type: application/json',
+            '-d', '{"publishing_type":"user_managed"}'
+        ]
+        def uploadProc = uploadCmd.execute()
+        uploadProc.waitFor()
+        if (uploadProc.exitValue() != 0) {
+            throw new GradleException("Failed to upload to repository")
+        }
+        println "Upload response:"
+        println uploadProc.text
+        println ""
+        
+        println "=========================================="
+        println "Release ${versionName} completed successfully!"
+        println "=========================================="
+        println ""
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/pokepaylib/build.gradle
+++ b/pokepaylib/build.gradle
@@ -57,55 +57,6 @@ artifacts {
     archives androidSourcesJar
 }
 
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            repository url: "file://${repo.absolutePath}"
-            pom.version = '2.0.22'	      // version
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            repository(url: "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-
-            snapshotRepository(url: "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/") {
-                authentication(userName: ossrhUsername, password: ossrhPassword)
-            }
-
-            pom.project {
-                name 'Pokepay Android SDK'
-                packaging 'aar'
-                // optionally artifactId can be defined here
-                description 'This is an SDK for embedding Pokepay\'s payment platform into Android applications.'
-                url 'https://docs.pokepay.jp/guidelines/app-sdk/java.html'
-
-                scm {
-                    connection 'scm:git:git://github.com/pokepay/android-sdk.git'
-                    developerConnection 'scm:git:ssh://github.com/pokepay/android-sdk.git'
-                    url 'https://github.com/pokepay/android-sdk'
-                }
-
-                licenses {
-                    license {
-                        name 'The Apache License, Version 2.0'
-                        url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id 'ann.lin'
-                        name 'Ann Lin'
-                        email 'ann.lin@coilinc.jp'
-                    }
-                }
-            }
-            pom.groupId = 'jp.pocket-change.pokepay.android-sdk'    // グループ名
-            pom.artifactId = 'pokepaylib'     // ライブラリ名
-        }
-    }
-}
-
 publishing {
     publications {
         mavenAar(MavenPublication) {

--- a/pokepaylib/build.gradle
+++ b/pokepaylib/build.gradle
@@ -1,12 +1,7 @@
-apply plugin: 'com.android.library'
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
-    }
+plugins {
+    id 'com.android.library'
+    id 'maven-publish'
+    id 'signing'
 }
 
 android {
@@ -69,11 +64,11 @@ uploadArchives {
             pom.version = '2.0.22'	      // version
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-            repository(url: "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/") {
+            repository(url: "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }
 
-            snapshotRepository(url: "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+            snapshotRepository(url: "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }
 
@@ -110,7 +105,60 @@ uploadArchives {
         }
     }
 }
+
+publishing {
+    publications {
+        mavenAar(MavenPublication) {
+            groupId = 'jp.pocket-change.pokepay.android-sdk'
+            artifactId = 'pokepaylib'
+            version = '2.0.22'
+
+            artifact("$buildDir/outputs/aar/pokepaylib-release.aar")
+
+            pom {
+                name = 'Pokepay Android SDK'
+                description = 'This is an SDK for embedding Pokepay\'s payment platform into Android applications.'
+                url = 'https://docs.pokepay.jp/guidelines/app-sdk/java.html'
+
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'ann.lin'
+                        name = 'Ann Lin'
+                        email = 'ann.lin@coilinc.jp'
+                    }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/pokepay/android-sdk.git'
+                    developerConnection = 'scm:git:ssh://github.com/pokepay/android-sdk.git'
+                    url = 'https://github.com/pokepay/android-sdk'
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "OSSRH"
+            url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
+            credentials {
+                username = ossrhUsername
+                password = ossrhPassword
+            }
+        }
+    }
+}
+
+
+
 apply plugin: 'signing'
 signing {
-    sign configurations.archives
+    sign publishing.publications.mavenAar
 }

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# Release script for Pokepay Android SDK
+# This script automates the release process including build, tag, publish, and deployment
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+echo "=========================================="
+echo "Pokepay Android SDK Release Script"
+echo "=========================================="
+echo ""
+
+# Extract version from pokepaylib/build.gradle
+echo "Reading version from pokepaylib/build.gradle..."
+VERSION=$(grep -E "versionName\s+\"" pokepaylib/build.gradle | sed -E 's/.*versionName\s+"([^"]+)".*/\1/')
+
+if [ -z "$VERSION" ]; then
+    echo "Error: Could not extract version from pokepaylib/build.gradle"
+    exit 1
+fi
+
+echo "Found version: $VERSION"
+echo ""
+
+# Extract credentials from gradle.properties
+echo "Reading credentials from gradle.properties..."
+OSSRH_USERNAME=$(grep "^ossrhUsername=" gradle.properties | cut -d'=' -f2)
+OSSRH_PASSWORD=$(grep "^ossrhPassword=" gradle.properties | cut -d'=' -f2)
+
+if [ -z "$OSSRH_USERNAME" ] || [ -z "$OSSRH_PASSWORD" ]; then
+    echo "Error: Could not extract credentials from gradle.properties"
+    echo "Please ensure ossrhUsername and ossrhPassword are set in gradle.properties"
+    exit 1
+fi
+
+echo "Credentials loaded successfully"
+echo ""
+
+# Confirm with user
+read -p "Proceed with release version $VERSION? (y/n): " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Release cancelled by user"
+    exit 1
+fi
+echo ""
+
+# Step 1: Clean and Build
+echo "Step 1/5: Cleaning and building project..."
+./gradlew clean
+if [ $? -ne 0 ]; then
+    echo "Error: gradlew clean failed"
+    exit 1
+fi
+
+./gradlew build
+if [ $? -ne 0 ]; then
+    echo "Error: gradlew build failed"
+    exit 1
+fi
+echo "Build completed successfully"
+echo ""
+
+# Step 2: Git Tag
+echo "Step 2/5: Creating and pushing git tag $VERSION..."
+git tag "$VERSION"
+if [ $? -ne 0 ]; then
+    echo "Error: git tag failed (tag may already exist)"
+    exit 1
+fi
+
+git push --tags
+if [ $? -ne 0 ]; then
+    echo "Error: git push --tags failed"
+    exit 1
+fi
+echo "Git tag created and pushed successfully"
+echo ""
+
+# Step 3: Publish
+echo "Step 3/5: Publishing to Maven repository..."
+./gradlew publish
+if [ $? -ne 0 ]; then
+    echo "Error: gradlew publish failed"
+    exit 1
+fi
+echo "Published successfully"
+echo ""
+
+# Step 4: Search for open repositories
+echo "Step 4/5: Searching for open repositories..."
+SEARCH_RESPONSE=$(curl -s -u "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" \
+    -H "Accept: application/json" \
+    "https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?state=open")
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to search for open repositories"
+    exit 1
+fi
+
+echo "Open repositories response:"
+echo "$SEARCH_RESPONSE" | jq '.' 2>/dev/null || echo "$SEARCH_RESPONSE"
+echo ""
+
+# Step 5: Upload to repository
+echo "Step 5/5: Uploading to Sonatype repository..."
+UPLOAD_RESPONSE=$(curl -s -u "${OSSRH_USERNAME}:${OSSRH_PASSWORD}" \
+    -X POST "https://ossrh-staging-api.central.sonatype.com/manual/upload/repository/${OSSRH_USERNAME}/219.104.131.128/jp.pocket-change.pokepay.android-sdk--default-repository" \
+    -H "Content-Type: application/json" \
+    -d '{"publishing_type":"user_managed"}')
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to upload to repository"
+    exit 1
+fi
+
+echo "Upload response:"
+echo "$UPLOAD_RESPONSE" | jq '.' 2>/dev/null || echo "$UPLOAD_RESPONSE"
+echo ""
+
+echo "=========================================="
+echo "Release $VERSION completed successfully!"
+echo "=========================================="
+echo ""

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,6 +21,7 @@ android {
     }
     lintOptions {
         abortOnError false
+        checkReleaseBuilds false
     }
     android {
         compileOptions {


### PR DESCRIPTION
This change should now add a release script to be able to *hopefully* simplify the release process for android SDK by just running `./release.sh` in the root of the project to build and release the project now.

This change should also allow us to run the release process as a gradle task in android studio with `gradlew release`. With the only difference from the `./release.sh` being the lack of user confirmation step requiring (y/n) input. This is due to limitations within the gradle terminal in android studio being not a true interactive console, thus prompts like System.console defaulting to `null` and auto failing when requesting for prompts.

Just remember to update your `ossrhUsername` and `ossrhPassword` in gradle.properties.