### PR TITLE
Top up method settings for Private Money

### DIFF
--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/PrivateMoney.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/PrivateMoney.java
@@ -36,5 +36,14 @@ public class PrivateMoney extends Response {
     @NonNull
     public boolean      can_use_c2c_transfer;
     public String       custom_domain_name;
+    public TopupMethod[] topup_methods;
+
+    public TopupMethod getCreditCardTopupMethod() {
+        if (topup_methods == null) return null;
+        for (TopupMethod method : topup_methods) {
+            if (method.isCreditCard()) return method;
+        }
+        return null;
+    }
 }
 

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/PrivateMoney.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/PrivateMoney.java
@@ -37,13 +37,5 @@ public class PrivateMoney extends Response {
     public boolean      can_use_c2c_transfer;
     public String       custom_domain_name;
     public TopupMethod[] topup_methods;
-
-    public TopupMethod getCreditCardTopupMethod() {
-        if (topup_methods == null) return null;
-        for (TopupMethod method : topup_methods) {
-            if (method.isCreditCard()) return method;
-        }
-        return null;
-    }
 }
 

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/TopupMethod.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/TopupMethod.java
@@ -1,0 +1,16 @@
+package jp.pokepay.pokepaylib.Responses;
+
+import jp.pokepay.pokepaylib.Response;
+
+public class TopupMethod extends Response {
+    public static final String TYPE_CREDIT_CARD = "credit-card";
+
+    public String type;
+    public String name;
+    public double[] amounts;
+    public double[] range;
+
+    public boolean isCreditCard() {
+        return TYPE_CREDIT_CARD.equals(type);
+    }
+}

--- a/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/TopupMethod.java
+++ b/pokepaylib/src/main/java/jp/pokepay/pokepaylib/Responses/TopupMethod.java
@@ -3,14 +3,9 @@ package jp.pokepay.pokepaylib.Responses;
 import jp.pokepay.pokepaylib.Response;
 
 public class TopupMethod extends Response {
-    public static final String TYPE_CREDIT_CARD = "credit-card";
-
+    // "type" can be "credit-card", "sevenbank-atm", "paytree-bank", or "cvs"
     public String type;
     public String name;
     public double[] amounts;
     public double[] range;
-
-    public boolean isCreditCard() {
-        return TYPE_CREDIT_CARD.equals(type);
-    }
 }


### PR DESCRIPTION
This pull request adds support for handling different top-up methods in the `PrivateMoney` response, including a utility to easily identify and retrieve credit card top-up methods. The main changes introduce a new `TopupMethod` class and update the `PrivateMoney` class to utilize it.

Top-up methods support:

* Added a new `TopupMethod` class to represent available top-up methods, including fields for `type`, `name`, `amounts`, and `range`, and a helper method `isCreditCard()` to check if the method is a credit card.
* Updated the `PrivateMoney` class to include a `topup_methods` array and a `getCreditCardTopupMethod()` method to retrieve the first credit card top-up method, if available.